### PR TITLE
fix map encoding

### DIFF
--- a/lib/erlang/etf/map.rb
+++ b/lib/erlang/etf/map.rb
@@ -2,11 +2,11 @@ module Erlang
   module ETF
 
     #
-    # 1   | 4    | N    | N
-    # --- | ---- | ---- | ------
-    # 116 | Size | Keys | Values
+    # 1   | 4     | N
+    # --- | ----- | -----
+    # 116 | Arity | Pairs
     #
-    # The Size specifies the number of keys and values that
+    # The Size specifies the number of key-values Pairs that
     # follows the size descriptor.
     #
     # (see [`MAP_EXT`])
@@ -25,12 +25,9 @@ module Erlang
 
       deserialize do |buffer|
         size, = buffer.read(BYTES_32).unpack(UINT32BE_PACK)
-        self.keys = []
+        self.keys, self.values = [], []
         size.times do
-          self.keys << Terms.deserialize(buffer)
-        end
-        self.values = []
-        size.times do
+          self.keys   << Terms.deserialize(buffer)
           self.values << Terms.deserialize(buffer)
         end
         self


### PR DESCRIPTION
The order of keys and values in the serialized format of an Erlang map seems to be different than what was implemented.  It's (k1, v1, k2, v2, ...) instead of (k1, k2, ..., v1, v2, ...).
