### PR TITLE
Fix bug  in an encoding a map

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,12 @@ end
 
 group :test do
   gem "simplecov", require: false
+  gem 'rspec-its'
   if ENV['CI']
     gem 'coveralls', require: false
   end
 end
+
 
 # Specify your gem's dependencies in erlang-etf.gemspec
 gemspec

--- a/lib/erlang/etf/extensions/erlang-map.rb
+++ b/lib/erlang/etf/extensions/erlang-map.rb
@@ -12,11 +12,9 @@ module Erlang
 
         def __erlang_evolve__
           if size == 0
-            ETF::Map.new([], [])
+            ETF::Map.new([])
           else
-            ETF::Map.new(*map do |(key, value)|
-              [key.__erlang_evolve__, value.__erlang_evolve__]
-            end.transpose)
+            ETF::Map.new(map.map {|(key, value)| [key.__erlang_evolve__, value.__erlang_evolve__]}.flatten)
           end
         end
 

--- a/lib/erlang/etf/map.rb
+++ b/lib/erlang/etf/map.rb
@@ -18,10 +18,9 @@ module Erlang
 
       uint8 :tag, always: Terms::MAP_EXT
 
-      uint32be :size, always: -> { keys.size }
+      uint32be :size, always: -> { elements.size/2 }
 
-      term :keys,   type: :array
-      term :values, type: :array
+      term :elements, type: :array
 
       deserialize do |buffer|
         size, = buffer.read(BYTES_32).unpack(UINT32BE_PACK)
@@ -38,9 +37,8 @@ module Erlang
 
       finalize
 
-      def initialize(keys, values)
-        @keys   = keys
-        @values = values
+      def initialize(elements)
+        @elements = elements
       end
 
       def __ruby_evolve__

--- a/lib/erlang/etf/map.rb
+++ b/lib/erlang/etf/map.rb
@@ -16,7 +16,7 @@ module Erlang
     class Map
       include Term
 
-      uint8 :tag, always: Terms::MAP_EXT
+      uint8 :tag, always: Terms::MAP_EXT 
 
       uint32be :size, always: -> { elements.size/2 }
 
@@ -24,15 +24,11 @@ module Erlang
 
       deserialize do |buffer|
         size, = buffer.read(BYTES_32).unpack(UINT32BE_PACK)
-        self.keys = []
-        size.times do
-          self.keys << Terms.deserialize(buffer)
+        self.elements = []
+
+        (size*2).times do
+          self.elements << Terms.deserialize(buffer)
         end
-        self.values = []
-        size.times do
-          self.values << Terms.deserialize(buffer)
-        end
-        self
       end
 
       finalize
@@ -41,8 +37,9 @@ module Erlang
         @elements = elements
       end
 
+      
       def __ruby_evolve__
-        ::Erlang::Map[keys.map(&:__ruby_evolve__).zip(values.map(&:__ruby_evolve__))]
+        ::Erlang::Map[*elements.map(&:__ruby_evolve__)]
       end
     end
   end

--- a/lib/erlang/etf/map.rb
+++ b/lib/erlang/etf/map.rb
@@ -2,9 +2,9 @@ module Erlang
   module ETF
 
     #
-    # 1   | 4    | N    | N
-    # --- | ---- | ---- | ------
-    # 116 | Size | Keys | Values
+    # 1   | 4    | N    
+    # --- | ---- | ---- 
+    # 116 | Size | Pairs
     #
     # The Size specifies the number of keys and values that
     # follows the size descriptor.

--- a/spec/erlang/etf/extensions/erlang-map_spec.rb
+++ b/spec/erlang/etf/extensions/erlang-map_spec.rb
@@ -6,21 +6,19 @@ describe Erlang::ETF::Extensions::ErlangMap do
   let(:klass) { ::Erlang::Map }
 
   describe '[instance]' do
-    let(:instance) { klass[keys.zip(values)] }
+    let(:instance) { klass[elements] }
 
     describe '__erlang_type__' do
       subject { instance.__erlang_type__ }
 
       context 'when empty' do
-        let(:keys)   { [] }
-        let(:values) { [] }
+        let(:elements)   { [] }
 
         it { should eq(:map) }
       end
 
       context 'when not empty' do
-        let(:keys)   { [:a] }
-        let(:values) { [1] }
+        let(:elements)   { [[:a, 1]] }
 
         it { should eq(:map) }
       end
@@ -30,17 +28,15 @@ describe Erlang::ETF::Extensions::ErlangMap do
       subject { instance.__erlang_evolve__ }
 
       context 'when empty' do
-        let(:keys)   { [] }
-        let(:values) { [] }
-
-        it { should eq(Erlang::ETF::Map.new([], [])) }
+        let(:elements)   { [] }
+        
+        it { should eq(Erlang::ETF::Map.new([])) }
       end
 
       context 'when not empty' do
-        let(:keys)   { [:a] }
-        let(:values) { [1] }
+        let(:elements)   { [[:a, 1]] }
 
-        it { should eq(Erlang::ETF::Map.new([Erlang::ETF::SmallAtom.new("a")], [Erlang::ETF::SmallInteger.new(1)])) }
+        it { should eq( Erlang::ETF::Map.new([Erlang::ETF::SmallAtom.new("a"), Erlang::ETF::SmallInteger.new(1)]) ) }
       end
     end
   end

--- a/spec/erlang/etf/map_spec.rb
+++ b/spec/erlang/etf/map_spec.rb
@@ -6,14 +6,16 @@ require 'pry'
 describe Erlang::ETF::Map do
   let(:term_class) { Erlang::ETF::Map }
 
-  let(:atom)          { Erlang::ETF::SmallAtom.new("test").tap(&:serialize) }
+  let(:atom)          { Erlang::ETF::Atom.new("test").tap(&:serialize) }
   let(:binary)        { Erlang::ETF::Binary.new("test").tap(&:serialize) }
   let(:new_float)     { Erlang::ETF::NewFloat.new(1.1) }
   let(:small_integer) { Erlang::ETF::SmallInteger.new(13) }
   let(:small_list)    { Erlang::ETF::List.new([atom, binary, new_float, small_integer]) }
+  #let(:small_list)    { Erlang::ETF::List.new([atom, binary, new_float, small_integer]) }
   let(:erlang_nil)    { Erlang::ETF::Nil.new }
   let(:small_tuple)   { Erlang::ETF::SmallTuple.new([atom, binary, new_float, small_integer, small_list]) }
-  let(:small_map)     { Erlang::ETF::Map.new([atom, binary, new_float], [small_integer, erlang_nil, small_list]) }
+  #let(:small_map)     { Erlang::ETF::Map.new([atom, binary, new_float], [small_integer, erlang_nil, small_list]) }
+  let(:small_map)     { Erlang::ETF::Map.new([atom, small_integer, binary, erlang_nil, new_float, small_list]) }
 
   describe '[class]' do
     describe 'deserialize' do
@@ -21,46 +23,44 @@ describe Erlang::ETF::Map do
       subject { term_class.deserialize(buffer) }
 
       context 'single item map' do
-        let(:bytes) { [0, 0, 0, 1, 100, 0, 1, 97, 106] }
+        let(:bytes) { [0, 0, 0, 1, 100, 0, 1, 97, 100, 0, 3, 110, 105, 108] }
         let(:atom_a) { Erlang::ETF::Atom.new("a").tap(&:serialize) }
 
         its(:size)   { should eq(1) }
-        its(:keys)   { should eq([atom_a]) }
-        its(:values) { should eq([erlang_nil]) }
+        its(:elements)   { should eq([ atom_a, Erlang::ETF::Atom.new("nil")]) }
       end
 
       context 'multiple item map' do
-        let(:bytes) { [0, 0, 0, 3, 115, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 108, 0, 0, 0, 4, 115, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106] }
+        let(:bytes) { [0, 0, 0, 3, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 100, 0, 4, 116, 101, 115, 116, 97, 13, 109, 0, 0, 0, 4, 116, 101, 115, 116, 106] }
+        #%{1.1 => [:test, "test", 1.1, 13], :test => 13, "test" => []}
 
         its(:size)   { should eq(3) }
-        its(:keys)   { should eq([atom, binary, new_float]) }
-        its(:values) { should eq([small_integer, erlang_nil, small_list]) }
+        its(:elements)   { should eq([new_float, small_list, atom, small_integer, binary, erlang_nil]) }
       end
     end
   end
 
   describe '[instance]' do
-    let(:term) { term_class.new(keys, values) }
+    let(:term) { term_class.new(elements) }
 
     let(:atom_a) { Erlang::ETF::Atom.new("a").tap(&:serialize) }
 
     describe 'serialize' do
-      subject { term.serialize }
+      subject { term.serialize.bytes }
 
       context 'single item map' do
-        let(:bytes) { [116, 0, 0, 0, 1, 100, 0, 1, 97, 106].pack('C*') }
+        #let(:bytes) { [116, 0, 0, 0, 1, 100, 0, 1, 97, 106].pack('C*') }
+        let(:bytes) { [116, 0, 0, 0, 1, 100, 0, 1, 97, 106] }
 
-        let(:keys)   { [atom_a] }
-        let(:values) { [erlang_nil] }
+        let(:elements) { [atom_a, erlang_nil] }
 
         it { should eq(bytes) }
       end
 
       context 'multiple item map' do
-        let(:bytes) { [116, 0, 0, 0, 3, 115, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 116, 0, 0, 0, 3, 115, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 108, 0, 0, 0, 4, 115, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 108, 0, 0, 0, 4, 115, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106].pack('C*') }
+        let(:bytes) { [116, 0, 0, 0, 3, 100, 0, 4, 116, 101, 115, 116, 97, 13, 109, 0, 0, 0, 4, 116, 101, 115, 116, 116, 0, 0, 0, 3, 100, 0, 4, 116, 101, 115, 116, 97, 13, 109, 0, 0, 0, 4, 116, 101, 115, 116, 106, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106] }
 
-        let(:keys)   { [atom, binary, new_float] }
-        let(:values) { [small_integer, small_map, small_list] }
+        let(:elements)   { [atom, small_integer, binary, small_map, new_float, small_list] }
 
         it { should eq(bytes) }
       end
@@ -69,8 +69,8 @@ describe Erlang::ETF::Map do
     describe '__erlang_type__' do
       subject { term.__erlang_type__ }
 
-      let(:keys)   { [atom_a] }
-      let(:values) { [erlang_nil] }
+      let(:elements)   { [atom_a, erlang_nil] }
+
       it { should eq(:map) }
     end
 
@@ -79,9 +79,8 @@ describe Erlang::ETF::Map do
         let(:ruby_obj) { ::Erlang::Map[:a, :a] }
         subject { term.__ruby_evolve__ }
 
-        let(:keys)   { [atom_a] }
-        let(:values) { [atom_a] }
-
+        let(:elements)   { [atom_a, atom_a] }
+        
         it { should eq(ruby_obj) }
       end
 
@@ -89,8 +88,7 @@ describe Erlang::ETF::Map do
         let(:ruby_obj) { ::Erlang::Map[:test, "test", 1.1, 13, ::Erlang::Tuple[:test, "test", 1.1, 13, ::Erlang::List[:test, "test", 1.1, 13]], ::Erlang::List[:test, "test", 1.1, 13]] }
         subject { term.__ruby_evolve__ }
 
-        let(:keys)   { [atom, new_float, small_tuple] }
-        let(:values) { [binary, small_integer, small_list] }
+        let(:elements)   { [atom, binary, new_float, small_integer, small_tuple, small_list] }
 
         it { should eq(ruby_obj) }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'erlang/etf'
-
+require 'rspec/its'
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true


### PR DESCRIPTION
**Hello,** 
  
  I fixed mistake in an encoding a map (Erlang::ETF::Map) and tests were edited. Could you update the gem. **This gem can be useful for connecting a ruby (RoR) app with an Elixir (Phoenix websockets) app**
  
(http://erlang.org/doc/apps/erts/erl_ext_dist.html#MAP_EXT)
    
```
-     1     | 4      | N        | N
-     ----- | ------ | ------- | ------
-     116 | Size | Keys  | Values

+    1     | 4       | N    
+    ----- |------- | ---- 
+    116 | Size | Pairs

```

**Tests were passed**

Finished in 0.63587 seconds (files took 0.51004 seconds to load)
**1006 examples, 0 failures**

Randomized with seed 62287


**Examples**


**From erlang (elixir iex)**
```

iex(54)> :erlang.term_to_binary(%{1.1 => [:test, "test", 1.1, 13], :test => 13, "test" => %{1.1 => [:test, "test", 1.1, 13], :test => 13}}) 

<<131, 116, 0, 0, 0, 3, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 100, 0, 4, 116, 101, 115, 116, 97, 13, 109, 0, 0, 0, 4, 116, 101, 115, 116, 116, 0, 0, 0, 2, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 100, 0, 4, 116, 101, 115, 116, 97, 13>>



```


**Ruby (irb)**

```
2.2.4 :270 >   map = Erlang.binary_to_term( [131, 116, 0, 0, 0, 3, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 100, 0, 4, 116, 101, 115, 116, 97, 13, 109, 0, 0, 0, 4, 116, 101, 115, 116, 116, 0, 0, 0, 2, 70, 63, 241, 153, 153, 153, 153, 153, 154, 108, 0, 0, 0, 4, 100, 0, 4, 116, 101, 115, 116, 109, 0, 0, 0, 4, 116, 101, 115, 116, 70, 63, 241, 153, 153, 153, 153, 153, 154, 97, 13, 106, 100, 0, 4, 116, 101, 115, 116, 97, 13].pack('C*') )
 => #<Erlang::Map #{1.1=>#<Erlang::List [:test, "test", 1.1, 13 | []]>, :test=>13, "test"=>#<Erlang::Map #{1.1=>#<Erlang::List [:test, "test", 1.1, 13 | []]>, :test=>13}>}> 


```


**From Ruby**
```

 2.2.4 :279 >   map
 => #<Erlang::Map #{1.1=>#<Erlang::List [:test, "test", 1.1, 13 | []]>, :test=>13, "test"=>#<Erlang::Map #{1.1=>#<Erlang::List [:test, "test", 1.1, 13 | []]>, :test=>13}>}> 

 2.2.4 :282 > Erlang.term_to_binary(map)
 => "\x83t\x00\x00\x00\x03F?\xF1\x99\x99\x99\x99\x99\x9Al\x00\x00\x00\x04s\x04testm\x00\x00\x00\x04testF?\xF1\x99\x99\x99\x99\x99\x9Aa\rjs\x04testa\rm\x00\x00\x00\x04testt\x00\x00\x00\x02F?\xF1\x99\x99\x99\x99\x99\x9Al\x00\x00\x00\x04s\x04testm\x00\x00\x00\x04testF?\xF1\x99\x99\x99\x99\x99\x9Aa\rjs\x04testa\r"

```

**Erlang (elixir iex)**

```

 iex(60)> :erlang.binary_to_term("\x83t\x00\x00\x00\x03F?\xF1\x99\x99\x99\x99\x99\x9Al\x00\x00\x00\x04s\x04testm\x00\x00\x00\x04testF?\xF1\x99\x99\x99\x99\x99\x9Aa\rjs\x04testa\rm\x00\x00\x00\x04testt\x00\x00\x00\x02F?\xF1\x99\x99\x99\x99\x99\x9Al\x00\x00\x00\x04s\x04testm\x00\x00\x00\x04testF?\xF1\x99\x99\x99\x99\x99\x9Aa\rjs\x04testa\r")                                                        
 %{1.1 => [:test, "test", 1.1, 13], :test => 13, "test" => %{1.1 => [:test, "test", 1.1, 13], :test => 13}}


```