### PR TITLE
throw EOFError when reading from IO

### DIFF
--- a/lib/erlang/etf.rb
+++ b/lib/erlang/etf.rb
@@ -274,7 +274,7 @@ module Erlang
 
     # @private
     def self.binary_to_term(buffer, etf)
-      magic = buffer.getc
+      magic = buffer.readchar
       if magic == Erlang::ETF::Term::ERLANG_MAGIC_BYTE
         term = nil
         begin

--- a/lib/erlang/etf.rb
+++ b/lib/erlang/etf.rb
@@ -287,7 +287,7 @@ module Erlang
         return term
       else
         buffer.ungetc(magic)
-        raise NotImplementedError, "unknown Erlang magic byte #{magic.inspect} (should be #{Erlang::ETF::Term::ERLANG_MAGIC_BYTE.inspect})"
+        raise ArgumentError, "unknown Erlang magic byte #{magic.inspect} (should be #{Erlang::ETF::Term::ERLANG_MAGIC_BYTE.inspect})"
       end
       # mzbuffer.read(1)
       # magic = buffer.read(1)

--- a/test/erlang/etf_test.rb
+++ b/test/erlang/etf_test.rb
@@ -13,7 +13,7 @@ class Erlang::ETFTest < Minitest::Test
   def test_binary_to_term
     assert_equal 0, Erlang::ETF.binary_to_term(StringIO.new([131,97,0].pack('C*')), false)
     assert_equal Erlang::ETF::SmallInteger[0], Erlang::ETF.binary_to_term(StringIO.new([131,97,0].pack('C*')), true)
-    assert_raises(NotImplementedError) { Erlang::ETF.binary_to_term(StringIO.new(""), false) }
+    assert_raises(EOFError) { Erlang::ETF.binary_to_term(StringIO.new(""), false) }
   end
 
   # def test_term_to_binary_with_unknown_term

--- a/test/erlang_test.rb
+++ b/test/erlang_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class ErlangTest < Minitest::Test
 
   def test_binary_to_term_without_magic_byte
-    assert_raises(NotImplementedError) { Erlang.binary_to_term("") }
+    assert_raises(EOFError) { Erlang.binary_to_term("") }
   end
 
   def test_term_to_binary_when_term_cannot_evolve

--- a/test/erlang_test.rb
+++ b/test/erlang_test.rb
@@ -8,6 +8,10 @@ class ErlangTest < Minitest::Test
     assert_raises(EOFError) { Erlang.binary_to_term("") }
   end
 
+  def test_binary_to_term_wrong_magic_byte
+    assert_raises(ArgumentError) { Erlang.binary_to_term("\x82") }
+  end
+
   def test_term_to_binary_when_term_cannot_evolve
     assert_raises(ArgumentError) { Erlang.term_to_binary(Object.new) }
   end


### PR DESCRIPTION
I was running into trouble reading multiple terms from an IO. This addresses that problem.

Also, it seemed to me that NotImplementedError was the wrong exception for an incorrect magic byte, so I changed that to ArgumentError.